### PR TITLE
Add a development flag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ guard :webpack, colors: false
 ### List of available options
 
 ```ruby
+d: false              # development mode turns on debug mode, source maps, and path info, default: false
 colors: true          # use colors in displaying webpack output, default: true
 progress: true        # display a progress bar for long compiles, default: true
 ```

--- a/lib/guard/webpack.rb
+++ b/lib/guard/webpack.rb
@@ -4,6 +4,7 @@ module Guard
     require 'guard/webpack/runner'
 
     DEFAULT_OPTIONS = {
+      d:        false,
       progress: true,
       colors:   true
     }

--- a/lib/guard/webpack/runner.rb
+++ b/lib/guard/webpack/runner.rb
@@ -43,6 +43,7 @@ class Guard::Webpack::Runner
 
   def option_flags
     output = ""
+    output += " -d"         if @options[:d]
     output += " --colors"   if @options[:colors]
     output += " --progress" if @options[:progress]
     output


### PR DESCRIPTION
I use guard-webpack in development mode, so when using it locally, it'd be nice if the `-d` development flag was enabled to turn on source maps and debug mode. This PR adds that option, but defaults it to false.
