### PR TITLE
Let guard start the runner & bump version

### DIFF
--- a/lib/guard/webpack.rb
+++ b/lib/guard/webpack.rb
@@ -14,7 +14,6 @@ module Guard
       with_defaults(args[-1]) do |opts|
         super(opts)
         @runner = Runner.new(opts)
-        @runner.start
       end
     end
 

--- a/lib/guard/webpack/version.rb
+++ b/lib/guard/webpack/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module WebpackVersion
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
Thanks for starting guard webpack. This changes guard-webpack so that guard-webpack respects running with groups or plugins, the current behavior is that it ignores the group or plugin argument given to guard.
