### PR TITLE
FIX: 2.3.1/lib/ruby/gems/2.3.0/gems/guard-webpack-0.1.2/lib/guard/web…

### DIFF
--- a/lib/guard/webpack.rb
+++ b/lib/guard/webpack.rb
@@ -1,5 +1,7 @@
+require "guard/compat/plugin"
+
 module Guard
-  class Webpack < ::Guard.const_get(::Guard.const_defined?(:Plugin) ? :Plugin : :Guard)
+  class Webpack < Plugin
     require 'guard/webpack/version'
     require 'guard/webpack/runner'
 


### PR DESCRIPTION
[FIX: Warning Using Guard #6](https://github.com/gisikw/guard-webpack/issues/6)

…pack.rb:2:in `module:Guard': superclass must be a Class (Module given) (TypeError)
