### PR TITLE
Fix behavior on run_all guard hook

### DIFF
--- a/lib/guard/webpack.rb
+++ b/lib/guard/webpack.rb
@@ -19,7 +19,7 @@ module Guard
     end
 
     def run_on_modifications(p);  @runner.restart;  end
-    def run_all;                  @runner.restart;  end
+    def run_all;                  @runner.start;    end
     def reload;                   @runner.restart;  end
     def start;                    @runner.start;    end
     def stop;                     @runner.stop;     end


### PR DESCRIPTION
To be consistent with Guard terminology - worker shouldn't be restarted if it receives run_all from guard - it should just start if not started yet.
